### PR TITLE
Clean up site, add link to 2024 highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Registration, funding, and hotel block information TBA.
 
 ## What is it?
 
+_Take a look at some [Cookbooks that got made at the 2024 Cook-off](https://projectpythia.org/posts/new-cookbooks.html) event!_
+
 Project Pythia continues offering its annual _Cook-off_ hackathon for creating and maintaining Pythia Cookbooks. [Pythia Cookbooks](https://cookbooks.projectpythia.org) are crowd-sourced collections of domain-specific tutorials and exemplar workflows, building upon our [Pythia Foundations](https://foundations.projectpythia.org) tutorials. Cookbooks are supported by a rich GitHub-based infrastructure enabling collaborative authoring and automated health-checking to ensure reproducibility.
 
 Participants in the Cook-off will develop their skills in contributing code and non-code to open source projects, demonstrating open science practices, and communicating and collaborating with other professionals. By doing so, they will grow the collection of accessible, reusable, and reproducible Cookbooks. This is a space for scientists, educators, and developers to bring their ideas, existing code, or rough notebooks and collaborate on turning them into community Cookbooks.

--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ sphinx:
     html_permalinks_icon: '<i class="fas fa-link"></i>'
     html_theme_options:
       home_page_in_toc: true
-      repository_url: https://github.com/ProjectPythia/cookbook-template/ # Online location of your book
+      repository_url: https://github.com/ProjectPythia/pythia-cookoff-2025/ # Online location of your book
       repository_branch: main # Which branch of the repository should be used when creating links (optional)
       use_issues_button: true
       use_repository_button: true

--- a/_toc.yml
+++ b/_toc.yml
@@ -1,9 +1,11 @@
 format: jb-book
 root: README
-parts:
-  - caption: Preamble
-    chapters:
-      - file: notebooks/how-to-cite
-  - caption: Introduction
-    chapters:
-      - file: notebooks/notebook-template
+# parts:
+#   - caption: Essential info
+#     chapters:
+#       - file: schedule
+#       - file: travel
+#       - file: breakouts
+#       - file: virtual
+#       - file: onboarding
+#       - file: faq


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR cleans up the landing page for the website, and also adds a link to our [blog post about last year's event](https://projectpythia.org/posts/new-cookbooks.html).

This should get this website ready to be blasted out to the world as a "save the date".