### PR TITLE
Put previous hotel recommendations back

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -6,7 +6,7 @@ Participant Travel Support (PTS) will be made available for a limited number of 
 
 ## Are there recommended hotels for this event?
 
-The recommended hotel for this event is the [Fairfield Inn](https://www.marriott.com/en-us/hotels/vboff-fairfield-inn-and-suites-boulder/overview/) on Center Green.  We will not be reserving a hotel block for this event.
+We will not be reserving a hotel block for this event. For hotel recommendations, see the [travel page](travel).
 
 ## I don't know anything about how to build a Cookbook, should I attend?
 

--- a/travel.md
+++ b/travel.md
@@ -7,11 +7,16 @@ The 2024 Pythia Cook-off will be hosted at the NCAR Mesa Lab:
 1850 Table Mesa Dr.
 Boulder, CO 80305
 
-The recommended hotel for this event is the [Fairfield Inn](https://www.marriott.com/en-us/hotels/vboff-fairfield-inn-and-suites-boulder/overview/) on Center Green. 
+The recommended hotels for this event are 
+- The [Fairfield Inn](https://www.marriott.com/en-us/hotels/vboff-fairfield-inn-and-suites-boulder/overview/) on South Boulder Road. 
+- {del}`The [Residence Inn](https://www.marriott.com/en-us/hotels/vbocg-residence-inn-boulder/overview/) on Center Green.`
+- {del}`The [Courtyard Boulder](https://www.marriott.com/en-us/hotels/denbd-courtyard-boulder/overview/) on Pearl.`
 
 **Please ask for the "UCAR Project Pythia Cook-off government per diem rate."**
 
-If the suggested hotels fill up, reach out to CISL_Events@UCAR.edu.
+_Note that the hotels that have been crossed off above are booked up and no longer able to offer new reservations at the per diem rate._ 
+
+If you need additional guidance on hotels, reach out to CISL_Events@UCAR.edu.
 
 ## Funding for travel
 


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR restores information about previously recommended hotels to the travel page, along with a note explaining that some are no longer available.

This is necessary for administrative purposes for people who have already booked at the previously recommended hotels and need funding justification.