### PR TITLE
Update schedule.md with github session title

### DIFF
--- a/schedule.md
+++ b/schedule.md
@@ -9,7 +9,7 @@
 - 09:00 AM: Welcome Plenary (Main Seminar Room)
 - 10:00 AM: Project Pitches (Main Seminar Room)
 - 12:00 PM: Lunch (Cafeteria)
-- 01:00 PM: GitHub: Cookbook Repository Set-Up and First Commit (Main Seminar Room)
+- 01:00 PM: GitHub on 2i2c JupyterHub: Cookbook Repository Set-Up and First Commit (Main Seminar Room)
 - 02:00 PM: Hacking: Group Brainstorming (Breakout Rooms)
 - 04:30 PM: Afternoon Debrief (Main Seminar Room)
 - 05:00 PM: Adjourn


### PR DESCRIPTION
I wanted to change the title of the github and first commit session slightly to indicate that we are working on the 2i2c hub. My hope is that this name alerts people that even if they are comfortable with GitHub this session will be of value to them.