### PR TITLE
Fix break time from AM to PM

### DIFF
--- a/schedule.md
+++ b/schedule.md
@@ -32,7 +32,7 @@
 - 10:30 AM: 15 minute Break
 - 12:30 PM: Lunch (Cafeteria)
 - 01:30 PM: Hacking (Breakout Rooms)
-- 2:45 AM: 15 minute Break
+- 2:45 PM: 15 minute Break
 - 04:00 PM: Afternoon Debrief (Main Seminar Room)
 - 05:00 PM: Adjourn
 


### PR DESCRIPTION
I noticed a typo in the hackathon schedule. As excited as I am for our 15 minute break at 2:45am on Thursday, I'm more excited for the one at 2:45pm. I'm sure no one will actually be confused by this, but it's good practice for me to submit a PR.